### PR TITLE
Add HDF5 to VTU conversion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,11 @@
 
 ## Python utilities
 
-The repository also provides a small helper script, `paraview_mesh_metrics.py`, which exposes a `compute_quality_metrics` function for reading a `.vtu` file and computing its aspect ratio, minimum dihedral angle and skewness using ParaView's `MeshQuality` filter.
+The repository provides a couple of helper scripts:
+
+* `paraview_mesh_metrics.py` exposes a `compute_quality_metrics` function for
+  reading a `.vtu` file and computing its aspect ratio, minimum dihedral
+  angle and skewness using ParaView's `MeshQuality` filter.
+* `h5_to_vtu.py` converts meshes stored in an HDF5 file into a `.vtu`
+  representation. The script relies on the `meshio` package and preserves all
+  point, cell and field data supported by `meshio`.

--- a/h5_to_vtu.py
+++ b/h5_to_vtu.py
@@ -1,0 +1,56 @@
+"""Utility to convert HDF5-based meshes into VTK ``.vtu`` files.
+
+This script relies on :mod:`meshio` to load a mesh stored in a ``.h5`` file
+and write it back as an unstructured VTK file. All point, cell and field data
+supported by :mod:`meshio` is preserved.
+
+Example
+-------
+    python h5_to_vtu.py input.h5 output.vtu
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Optional
+
+try:  # pragma: no cover - meshio may not be available
+    import meshio
+except ModuleNotFoundError as exc:  # pragma: no cover - meshio is optional
+    raise ImportError("The meshio package is required to run this script.") from exc
+
+
+def convert(h5_file: str, vtu_file: str, file_format: Optional[str] = None) -> None:
+    """Convert ``h5_file`` into ``vtu_file`` using ``meshio``.
+
+    Parameters
+    ----------
+    h5_file : str
+        Path to the input ``.h5`` file.
+    vtu_file : str
+        Path to the output ``.vtu`` file.
+    file_format : Optional[str]
+        Optional format string understood by :func:`meshio.read`.
+    """
+    mesh = meshio.read(h5_file, file_format=file_format)
+    meshio.write(vtu_file, mesh, binary=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert .h5 mesh to .vtu.")
+    parser.add_argument("input_file", help="Path to the input .h5 file.")
+    parser.add_argument("output_file", help="Path of the generated .vtu file.")
+    parser.add_argument(
+        "--format",
+        dest="file_format",
+        help=(
+            "Optional meshio format name."
+            " Use this when the input file is not automatically detected."
+        ),
+    )
+    args = parser.parse_args()
+    convert(args.input_file, args.output_file, args.file_format)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()


### PR DESCRIPTION
## Summary
- add `h5_to_vtu.py` script to convert meshes stored in HDF5 files to VTU using meshio
- document new script in README

## Testing
- `ruff check h5_to_vtu.py`
- `black --check h5_to_vtu.py`
- `python -m pytest -q` *(fails: No module named pytest)*