### PR TITLE
Add CLI to mesh metrics utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,10 @@ The repository provides a couple of helper scripts:
 
 * `paraview_mesh_metrics.py` exposes a `compute_quality_metrics` function for
   reading a `.vtu` file and computing its aspect ratio, minimum dihedral
-  angle and skewness using ParaView's `MeshQuality` filter.
+  angle and skewness using ParaView's `MeshQuality` filter. The script can
+  also be run from the command line by passing the mesh file path:
+
+  ```bash
+  python paraview_mesh_metrics.py mesh.vtu
+  ```
 

--- a/paraview_mesh_metrics.py
+++ b/paraview_mesh_metrics.py
@@ -6,6 +6,8 @@ filter.
 """
 
 from typing import Dict, Any, List
+import argparse
+import json
 
 try:
     from paraview.simple import XMLUnstructuredGridReader, MeshQuality, Delete
@@ -77,4 +79,20 @@ def compute_quality_metrics(vtu_path: str) -> Dict[str, Any]:
     Delete(reader)
     return metrics
 
+
+def _main() -> None:
+    """Entry point for command line execution."""
+    parser = argparse.ArgumentParser(
+        description="Compute mesh quality metrics for a VTU file using ParaView"
+    )
+    parser.add_argument("mesh", help="Path to the input .vtu mesh file")
+    args = parser.parse_args()
+
+    metrics = compute_quality_metrics(args.mesh)
+    print(json.dumps(metrics, indent=2))
+
+
 __all__ = ["compute_quality_metrics"]
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    _main()


### PR DESCRIPTION
## Summary
- expose `paraview_mesh_metrics.py` as a command line script
- show CLI usage in README

## Testing
- `python -m py_compile paraview_mesh_metrics.py`