### PR TITLE
Add Fluent mesh quality script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ The repository provides a couple of helper scripts:
   python paraview_mesh_metrics.py mesh.vtu
   ```
 
+* `paraview_mesh_metrics_fluent.py` offers the same functionality but for
+  Fluent `.h5` files using ParaView's Fluent reader. Invoke it in the same
+  way by providing the path to the `.h5` file:
+
+  ```bash
+  python paraview_mesh_metrics_fluent.py case.h5
+  ```
+

--- a/paraview_mesh_metrics_fluent.py
+++ b/paraview_mesh_metrics_fluent.py
@@ -1,0 +1,99 @@
+"""Utility to compute mesh quality metrics from Fluent ``.h5`` files.
+
+This module replicates :mod:`paraview_mesh_metrics` but uses the ParaView
+reader for Fluent ``.h5`` case files.  The metrics are computed using
+ParaView's built-in ``MeshQuality`` filter in the same way as for ``.vtu``
+meshes.
+"""
+
+from typing import Dict, Any, List
+import argparse
+import json
+
+try:
+    from paraview.simple import FluentReader, MeshQuality, Delete
+    from paraview.servermanager import Fetch
+except ModuleNotFoundError as exc:  # pragma: no cover - ParaView may not be installed
+    raise ImportError(
+        "ParaView is required to use this module. Make sure paraview.simple is available"
+    ) from exc
+
+
+def _compute_metric(reader: Any, measure: str) -> List[float]:
+    """Internal helper that returns the raw quality values for *measure*.
+
+    Parameters
+    ----------
+    reader : Any
+        The ParaView reader object for the input Fluent file.
+    measure : str
+        Name of the quality measure (e.g. ``'Aspect Ratio'``).
+
+    Returns
+    -------
+    List[float]
+        List containing the quality value for each cell in the mesh.
+    """
+    quality = MeshQuality(Input=reader)
+    quality.TetQualityMeasure = measure
+    quality.SaveCellQuality = 1
+
+    data = Fetch(quality)
+    array = data.GetCellData().GetArray("Quality")
+    values = [array.GetValue(i) for i in range(array.GetNumberOfTuples())]
+
+    Delete(quality)
+    return values
+
+
+def compute_quality_metrics(h5_path: str) -> Dict[str, Any]:
+    """Compute aspect ratio, minimum dihedral angle and skewness of a Fluent ``.h5`` file.
+
+    Parameters
+    ----------
+    h5_path : str
+        Path to the input Fluent ``.h5`` case or data file.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary with the statistics for each metric. ``min``/``max``/``avg``
+        are provided together with the list of per-cell values.
+    """
+    reader = FluentReader(FileName=[h5_path])
+
+    metrics = {}
+    for name, key in [
+        ("Aspect Ratio", "aspect_ratio"),
+        ("Minimum Dihedral Angle", "minimum_dihedral_angle"),
+        ("Skewness", "skewness"),
+    ]:
+        values = _compute_metric(reader, name)
+        stats = {
+            "values": values,
+            "min": min(values) if values else None,
+            "max": max(values) if values else None,
+            "avg": sum(values) / len(values) if values else None,
+        }
+        metrics[key] = stats
+
+    Delete(reader)
+    return metrics
+
+
+def _main() -> None:
+    """Entry point for command line execution."""
+    parser = argparse.ArgumentParser(
+        description="Compute mesh quality metrics for a Fluent .h5 file using ParaView"
+    )
+    parser.add_argument("mesh", help="Path to the input Fluent .h5 file")
+    args = parser.parse_args()
+
+    metrics = compute_quality_metrics(args.mesh)
+    print(json.dumps(metrics, indent=2))
+
+
+__all__ = ["compute_quality_metrics"]
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    _main()


### PR DESCRIPTION
## Summary
- add `paraview_mesh_metrics_fluent.py` to compute metrics from Fluent `.h5` files
- document new script in README

## Testing
- `python -m py_compile paraview_mesh_metrics_fluent.py`