### PR TITLE
Switch Fluent metrics script to OpenDataFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The repository provides a couple of helper scripts:
   ```
 
 * `paraview_mesh_metrics_fluent.py` offers the same functionality but for
-  Fluent `.h5` files using ParaView's Fluent reader. Invoke it in the same
+  Fluent `.h5` files using ParaView's built-in `OpenDataFile` function. Invoke it in the same
   way by providing the path to the `.h5` file:
 
   ```bash

--- a/paraview_mesh_metrics_fluent.py
+++ b/paraview_mesh_metrics_fluent.py
@@ -1,7 +1,7 @@
 """Utility to compute mesh quality metrics from Fluent ``.h5`` files.
 
-This module replicates :mod:`paraview_mesh_metrics` but uses the ParaView
-reader for Fluent ``.h5`` case files.  The metrics are computed using
+This module replicates :mod:`paraview_mesh_metrics` but uses ParaView's
+``OpenDataFile`` function to load Fluent ``.h5`` case files.  The metrics are computed using
 ParaView's built-in ``MeshQuality`` filter in the same way as for ``.vtu``
 meshes.
 """
@@ -11,7 +11,7 @@ import argparse
 import json
 
 try:
-    from paraview.simple import FluentReader, MeshQuality, Delete
+    from paraview.simple import OpenDataFile, MeshQuality, Delete
     from paraview.servermanager import Fetch
 except ModuleNotFoundError as exc:  # pragma: no cover - ParaView may not be installed
     raise ImportError(
@@ -25,7 +25,7 @@ def _compute_metric(reader: Any, measure: str) -> List[float]:
     Parameters
     ----------
     reader : Any
-        The ParaView reader object for the input Fluent file.
+        The dataset object returned by ``OpenDataFile`` for the input Fluent file.
     measure : str
         Name of the quality measure (e.g. ``'Aspect Ratio'``).
 
@@ -36,7 +36,8 @@ def _compute_metric(reader: Any, measure: str) -> List[float]:
     """
     quality = MeshQuality(Input=reader)
     quality.TetQualityMeasure = measure
-    quality.SaveCellQuality = 1
+    if hasattr(quality, "SaveCellQuality"):
+        quality.SaveCellQuality = 1
 
     data = Fetch(quality)
     array = data.GetCellData().GetArray("Quality")
@@ -60,7 +61,7 @@ def compute_quality_metrics(h5_path: str) -> Dict[str, Any]:
         Dictionary with the statistics for each metric. ``min``/``max``/``avg``
         are provided together with the list of per-cell values.
     """
-    reader = FluentReader(FileName=[h5_path])
+    reader = OpenDataFile(h5_path)
 
     metrics = {}
     for name, key in [


### PR DESCRIPTION
## Summary
- use OpenDataFile instead of FluentReader in `paraview_mesh_metrics_fluent.py`
- update docstrings to describe OpenDataFile usage
- document this change in the README
- avoid failures when `MeshQuality.SaveCellQuality` is unavailable

## Testing
- `python -m py_compile paraview_mesh_metrics_fluent.py`
