### PR TITLE
Switch Fluent metrics script to OpenDataFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The repository provides a couple of helper scripts:
   ```
 
 * `paraview_mesh_metrics_fluent.py` offers the same functionality but for
-  Fluent `.h5` files using ParaView's Fluent reader. Invoke it in the same
+  Fluent `.h5` files using ParaView's built-in `OpenDataFile` function. Invoke it in the same
   way by providing the path to the `.h5` file:
 
   ```bash


### PR DESCRIPTION
## Summary
- use OpenDataFile instead of FluentReader in `paraview_mesh_metrics_fluent.py`
- update docstrings to describe OpenDataFile usage
- document this change in the README
- handle Skewness vs Skew naming and multi-block datasets

## Testing
- `python -m py_compile paraview_mesh_metrics_fluent.py`